### PR TITLE
Fixed: Background for forgot password page.

### DIFF
--- a/public/styles/forgot-password.css
+++ b/public/styles/forgot-password.css
@@ -9,7 +9,7 @@
 }
 body{
     /* url for the background image  */
-    background: url("/image/food100.jpg");
+    background: url("/image/bg-1.jpg");
     background-size: cover;
     background-repeat: no-repeat;
     background-attachment: fixed;
@@ -21,6 +21,16 @@ body{
     align-items: center;
     min-height: 110vh;
     background: rgba(39, 39, 39, 0.4);
+}
+.wrapper::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: rgba(39, 39, 39, 0.5);
+    z-index: 0;
 }
 .nav{
     position: fixed;

--- a/public/templates/forgot-password.html
+++ b/public/templates/forgot-password.html
@@ -42,15 +42,11 @@
         <div class="login-container" id="login">
             <div class="top">
                 <!-- <span>Don't have an account? <a href="#" onclick="register()">Sign Up</a></span> -->
-                <header>forgot Password</header>
+                <header>Forgot Password</header>
             </div>
             <div class="input-box">
                 <input type="text" class="input-field" placeholder="Username or Email">
                 <i class="bx bx-user"></i>
-            </div>
-            <div class="input-box">
-                <input type="password" class="input-field" placeholder="Password">
-                <i class="bx bx-lock-alt"></i>
             </div>
             <div class="input-box">
                 <input type="submit" class="submit" value="Send mail">


### PR DESCRIPTION
 * Issue Solved -  #14

- Added the same image as background of Login page.

### Feature Requests -
- In `Forgot-Password` page , Removed `Password` input field as forgot password is used to generate new passwords.
- changed title `forgot Password` to `Forgot Password`.

- Updated `Forgot-password-page` -
![image](https://github.com/sagnik3788/FlavorFleet/assets/119523972/ac0b62f8-f273-428a-8b06-c6b1a27b6402)
